### PR TITLE
fix: remove redundant selection box from settings radio inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ temp/
 
 # YoYo AI version control directory
 .yoyo/
+
+# Android Studio
+.idea/
+
+# tldr
+.tldr/
+.tldrignore

--- a/app/(pages)/settings/language.tsx
+++ b/app/(pages)/settings/language.tsx
@@ -116,7 +116,6 @@ export default function LanguageSettingsScreen() {
                       enabled={!isSaving}
                     />
                   }
-                  selected={effectiveLanguageCode === language.code}
                   onPress={isSaving ? undefined : () => handleSelect(language)}
                   backgroundColor={theme.colors.surfacePrimary}
                 />

--- a/app/(pages)/settings/model.tsx
+++ b/app/(pages)/settings/model.tsx
@@ -103,7 +103,6 @@ export default function ModelSettingsScreen() {
                   enabled={!isSaving}
                 />
               }
-              selected={effectiveModelType === ModelType.WHISPER_FILE}
               onPress={
                 isSaving
                   ? undefined
@@ -130,7 +129,6 @@ export default function ModelSettingsScreen() {
                   enabled={!isSaving}
                 />
               }
-              selected={effectiveModelType === ModelType.WHISPER_REALTIME}
               onPress={
                 isSaving
                   ? undefined

--- a/app/(pages)/settings/theme.tsx
+++ b/app/(pages)/settings/theme.tsx
@@ -89,7 +89,6 @@ export default function ThemeSettingsScreen() {
                   enabled={!isSaving}
                 />
               }
-              selected={effectiveTheme === AppTheme.AUTO}
               onPress={isSaving ? undefined : () => handleSelect(AppTheme.AUTO)}
               backgroundColor={theme.colors.surfacePrimary}
             />
@@ -108,7 +107,6 @@ export default function ThemeSettingsScreen() {
                   enabled={!isSaving}
                 />
               }
-              selected={effectiveTheme === AppTheme.LIGHT}
               onPress={
                 isSaving ? undefined : () => handleSelect(AppTheme.LIGHT)
               }
@@ -129,7 +127,6 @@ export default function ThemeSettingsScreen() {
                   enabled={!isSaving}
                 />
               }
-              selected={effectiveTheme === AppTheme.DARK}
               onPress={isSaving ? undefined : () => handleSelect(AppTheme.DARK)}
               backgroundColor={theme.colors.surfacePrimary}
             />


### PR DESCRIPTION
## Summary
- Remove `selected` prop from `ListItem` components on theme, model, and language settings screens
- The Radio inputs already visually indicate the selected option (filled vs empty circle), making the highlighted selection box redundant
- Updated `.gitignore` to exclude Android Studio and tldr directories

## Test plan
- [ ] Open theme settings and verify no highlighted box around selected option
- [ ] Open model settings and verify no highlighted box around selected option
- [ ] Open language settings and verify no highlighted box around selected option
- [ ] Verify Radio inputs still correctly show filled circle for selected option
- [ ] Run `npm run lint` to confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)